### PR TITLE
OAEWDGT-162 - Fix typo in JS styleguide 

### DIFF
--- a/app/views/sdk/javascript.html.erb
+++ b/app/views/sdk/javascript.html.erb
@@ -311,14 +311,14 @@ setTimeout(function() {
         <p>Evil! Please avoid these.</p>
 
         <h2 id="object-array-creation">Object / Array creation</h2>
-        <p>Use trailing commas and put short declarations on a single line.</p>
+        <p>Put short declarations on a single line, and avoid using trailing commas.</p>
         <h4>Right:</h4>
         <div class="navigationalitems_codesnippit_container few_lines">
 <pre class="prettyprint">
 var a = ['hello', 'world'];
 var b = {
     'good': 'code',
-    'is generally': 'pretty',
+    'is generally': 'pretty'
 };
 </pre>
         </div>
@@ -329,7 +329,7 @@ var a = [
     'hello', 'world'
 ];
 var b = {"good": 'code'
-        , is generally: 'pretty'
+        , is generally: 'pretty',
         };
 </pre>
         </div>


### PR DESCRIPTION
Fixing typo in JS Styleguide to advise against using trailing commas in object notation.

https://jira.sakaiproject.org/browse/OAEWDGT-162
